### PR TITLE
Client side bundle loading with workarounds for (most) browser bugs

### DIFF
--- a/examples/webpack/index.html
+++ b/examples/webpack/index.html
@@ -12,7 +12,9 @@
   <div id="root-es5"></div>
   <div id="root-esm"></div>
 
-  <script nomodule src="/dist/index.legacy.js"></script>
-  <script type="module" src="/dist/index.esm.js"></script>
+  <!-- targeting ES2017 -->
+  <script type="module">window.ESM=!0;import'./dist/index.esm.js';</script>
+  <!-- targeting ES5 -->
+  <script nomodule defer src="ubl.js"></script>
 </body>
 </html>

--- a/examples/webpack/ubl.js
+++ b/examples/webpack/ubl.js
@@ -1,0 +1,7 @@
+(function(g,d,s){if(!g.ESM){
+    s=d.documentElement;
+    s=s.insertBefore(d.createElement('script'),s.lastChild);
+    s.defer=!0;
+    s.type='text/javascript';
+    s.src='/dist/index.legacy.js';
+  }}(window,document));


### PR DESCRIPTION
I did a quick test of my suggestion in #3, it seems to work better in the Edge version I have available (17), and seemed okay in the other browsers I tested too :-)

This uses the approach from https://medium.com/@WebReflection/a-universal-bundle-loader-6d7f3e628f93
Basically the deferring of 'ubl.js' should ensure browsers with bugs will load that file, but not any more files if ESM is supported.
I did simplify the script slightly, to only have a ES2017 and a ES5 bundle (not a ES2015 variant).